### PR TITLE
added camelcase fix for issue #1

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -7,6 +7,7 @@ use wit_parser::{Resolve, WorldId, WorldKey};
 /// Information about the component in the manifest. This is generally synthesized from a
 /// component's world
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Component {
     /// A list of all exports from the component
     pub exports: Vec<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub trait ToConfig {
 
 /// The config type struct for `application/wasm`
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct WasmConfig {
     /// The time when the config was created.
     pub created: DateTime<Utc>,


### PR DESCRIPTION
Even though `layer_digests` is the only field that it currently affects. It is good to have on the structs when other fields are added. OCI JSON schemas use `lowerCamelCase`.

https://serde.rs/attr-rename.html