### PR TITLE
fix(client): Swaps accidental use of digest and config strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1457,18 +1457,18 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
+checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c44e62d325ce9253f88c01f0f67be121356767d12f2f13e701fdcd99e1f5b0"
+checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1495,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
 dependencies = [
  "ahash",
  "bitflags",
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a411ff9c471737091b2c1a738a25031029fc4d0b8f1a60bef0e68906e9f6534b"
+checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
+checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oci-wasm"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Taylor Thomas <taylor@oftaylor.com>"]
 description = "A crate containing a thin wrapper around the oci-distribution crate that implements types and methods for pulling and pushing Wasm to OCI registries"
@@ -22,5 +22,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tokio = { version = "1", default-features = false, features = ["fs"] }
-wit-component = "0.207.0"
-wit-parser = "0.207"
+wit-component = "0.209"
+wit-parser = "0.209"

--- a/src/client.rs
+++ b/src/client.rs
@@ -56,7 +56,7 @@ impl WasmClient {
             .client
             .pull(image, auth, vec![WASM_LAYER_MEDIA_TYPE])
             .await?;
-        if image_data.layers.len() > 1 {
+        if image_data.layers.len() != 1 {
             anyhow::bail!("Wasm components must have exactly one layer");
         }
 
@@ -77,8 +77,8 @@ impl WasmClient {
         image: &Reference,
         auth: &RegistryAuth,
     ) -> anyhow::Result<(OciImageManifest, WasmConfig, String)> {
-        let (manifest, config, digest) = self.client.pull_manifest_and_config(image, auth).await?;
-        if manifest.layers.len() > 1 {
+        let (manifest, digest, config) = self.client.pull_manifest_and_config(image, auth).await?;
+        if manifest.layers.len() != 1 {
             anyhow::bail!("Wasm components must have exactly one layer");
         }
         if manifest.media_type.as_deref().unwrap_or_default() != WASM_MANIFEST_MEDIA_TYPE {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -100,29 +100,11 @@ async fn test_push_and_pull() {
         "Should have a manifest url in the response"
     );
 
-    // Now try to pull and make all the data is correct
-    let data = client
-        .pull(&image, &oci_distribution::secrets::RegistryAuth::Anonymous)
+    // Check that just pulling the manifest works and check the config
+    let (_, conf, _) = client
+        .pull_manifest_and_config(&image, &oci_distribution::secrets::RegistryAuth::Anonymous)
         .await
-        .expect("Should be able to pull component");
-    assert_eq!(
-        data.config.media_type, WASM_MANIFEST_CONFIG_MEDIA_TYPE,
-        "Should have the proper config media type"
-    );
-    assert_eq!(data.layers.len(), 1, "Should have exactly one layer");
-    assert_eq!(
-        data.layers[0].media_type, WASM_LAYER_MEDIA_TYPE,
-        "Should have the proper layer media type"
-    );
-    assert_eq!(
-        data.manifest
-            .expect("Should have manifest present")
-            .media_type
-            .expect("Must have media type"),
-        WASM_MANIFEST_MEDIA_TYPE,
-        "Should have the proper manifest media type"
-    );
-    let conf = WasmConfig::try_from(data.config.data).expect("Should be able to parse config");
+        .expect("Should be able to pull manifest and config");
     assert_eq!(
         conf.author.expect("Author should be set"),
         "Bugs Bunny",
@@ -166,6 +148,29 @@ async fn test_push_and_pull() {
     assert_eq!(
         imports, expected_imports,
         "Expected imports to match:\nGot: {imports:?}\nExpected:\n{expected_imports:?}"
+    );
+
+    // Now try to pull and make all the data is correct
+    let data = client
+        .pull(&image, &oci_distribution::secrets::RegistryAuth::Anonymous)
+        .await
+        .expect("Should be able to pull component");
+    assert_eq!(
+        data.config.media_type, WASM_MANIFEST_CONFIG_MEDIA_TYPE,
+        "Should have the proper config media type"
+    );
+    assert_eq!(data.layers.len(), 1, "Should have exactly one layer");
+    assert_eq!(
+        data.layers[0].media_type, WASM_LAYER_MEDIA_TYPE,
+        "Should have the proper layer media type"
+    );
+    assert_eq!(
+        data.manifest
+            .expect("Should have manifest present")
+            .media_type
+            .expect("Must have media type"),
+        WASM_MANIFEST_MEDIA_TYPE,
+        "Should have the proper manifest media type"
     );
 
     // As a sanity check, make sure we can still parse the bytes out (by loading a component)


### PR DESCRIPTION
Also a small bug that ensures there is _exactly_ one layer and not 0 layers