### PR TITLE
fix(component)!: Adds correct handling for binary wit packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oci-wasm"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 authors = ["Taylor Thomas <taylor@oftaylor.com>"]
 description = "A crate containing a thin wrapper around the oci-distribution crate that implements types and methods for pulling and pushing Wasm to OCI registries"

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use wit_parser::{Resolve, WorldId, WorldKey};
+use wit_parser::{PackageId, Resolve, WorldId};
 
 /// Information about the component in the manifest. This is generally synthesized from a
 /// component's world
@@ -33,13 +33,49 @@ impl Component {
             exports: world
                 .exports
                 .keys()
-                .filter_map(|key| name_from_key_and_item(resolve, key))
+                .map(|key| resolve.name_world_key(key))
                 .collect(),
             imports: world
                 .imports
                 .keys()
-                .filter_map(|key| name_from_key_and_item(resolve, key))
+                .map(|key| resolve.name_world_key(key))
                 .collect(),
+            target: None,
+        })
+    }
+
+    /// Create a component from a parsed [`Resolve`] and [`PackageId`]. This is a lower level
+    /// function for when you have already parsed a binary wit package and have the package ID and
+    /// resolve available. This outputs a component with all exports and an empty imports list.
+    ///
+    /// Returns an error only if the package doesn't exist in the resolve.
+    pub fn from_package(resolve: &Resolve, pkg_id: PackageId) -> anyhow::Result<Self> {
+        let pkg = resolve.packages.get(pkg_id).context("package not found")?;
+        let mut exports = pkg
+            .worlds
+            .iter()
+            .filter_map(|(_name, world_id)| {
+                let world = resolve.worlds.get(*world_id)?;
+                let mut exports = world
+                    .exports
+                    .keys()
+                    .map(|key| resolve.name_world_key(key))
+                    .collect::<Vec<_>>();
+                let mut fully_qualified_world =
+                    format!("{}:{}/{}", pkg.name.namespace, pkg.name.name, world.name);
+                if let Some(ver) = pkg.name.version.as_ref() {
+                    fully_qualified_world.push('@');
+                    fully_qualified_world.push_str(&ver.to_string());
+                }
+                exports.push(fully_qualified_world);
+                Some(exports)
+            })
+            .flatten()
+            .collect::<HashSet<_>>();
+        exports.extend(pkg.interfaces.values().filter_map(|id| resolve.id_of(*id)));
+        Ok(Component {
+            exports: exports.into_iter().collect(),
+            imports: vec![],
             target: None,
         })
     }
@@ -52,60 +88,13 @@ impl Component {
 
     /// Create a component from the raw bytes of the component
     pub fn from_raw_component(raw: impl AsRef<[u8]>) -> anyhow::Result<Self> {
-        let (resolve, world) = match wit_component::decode(raw.as_ref())
-            .context("failed to decode WIT component")?
-        {
-            wit_component::DecodedWasm::Component(resolve, world) => (resolve, world),
-            wit_component::DecodedWasm::WitPackage(..) => {
-                bail!("Found a binary wit package, not a component. Please use the from_wit_package or from_raw_wit_package functions")
+        match wit_component::decode(raw.as_ref()).context("failed to decode WIT component")? {
+            wit_component::DecodedWasm::Component(resolve, world) => {
+                Self::from_world(&resolve, world)
             }
-        };
-
-        Self::from_world(&resolve, world)
-    }
-
-    /// Create a component from the raw bytes of a binary wit package component
-    pub async fn from_wit_package(
-        path: impl AsRef<Path>,
-        world_name: impl AsRef<str>,
-    ) -> anyhow::Result<Self> {
-        let data = tokio::fs::read(path).await.context("Unable to read file")?;
-        Self::from_raw_wit_package(data, world_name)
-    }
-
-    /// Create a component from the raw bytes of a binary wit package component
-    pub fn from_raw_wit_package(
-        raw: impl AsRef<[u8]>,
-        world_name: impl AsRef<str>,
-    ) -> anyhow::Result<Self> {
-        let resolve = match wit_component::decode(raw.as_ref())
-            .context("failed to decode WIT component")?
-        {
-            wit_component::DecodedWasm::WitPackage(resolve, _) => resolve,
-            wit_component::DecodedWasm::Component(..) => {
-                bail!("Found a component, not a binary wit package. Please use the from_component or from_raw_component functions")
+            wit_component::DecodedWasm::WitPackage(resolve, pkg_id) => {
+                Self::from_package(&resolve, pkg_id)
             }
-        };
-
-        let world = resolve
-            .worlds
-            .iter()
-            .find_map(|(id, w)| (w.name == world_name.as_ref()).then_some(id))
-            .context(format!(
-                "Unable to find matching world for name {}",
-                world_name.as_ref()
-            ))?;
-
-        Self::from_world(&resolve, world)
-    }
-}
-
-fn name_from_key_and_item(resolve: &Resolve, key: &WorldKey) -> Option<String> {
-    match key {
-        WorldKey::Interface(id) => {
-            // This function returns the full name of the interface
-            resolve.id_of(*id)
         }
-        WorldKey::Name(name) => Some(name.to_owned()),
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,28 +50,21 @@ pub struct AnnotatedWasmConfig<'a> {
 impl WasmConfig {
     /// A helper for loading a component from a file and returning the proper config and
     /// [`ImageLayer`]. The returned config will have the created time set to now and all other
-    /// fields set for a component. If you are loading a binary wit package component, the
-    /// `world_name` argument is required
+    /// fields set for a component.
     pub async fn from_component(
         path: impl AsRef<std::path::Path>,
-        world_name: Option<&str>,
         author: Option<String>,
     ) -> anyhow::Result<(Self, ImageLayer)> {
         let raw = tokio::fs::read(path).await.context("Unable to read file")?;
-        Self::from_raw_component(raw, world_name, author)
+        Self::from_raw_component(raw, author)
     }
 
     /// Same as [`WasmConfig::from_component`] but for raw component bytes
     pub fn from_raw_component(
         raw: Vec<u8>,
-        world_name: Option<&str>,
         author: Option<String>,
     ) -> anyhow::Result<(Self, ImageLayer)> {
-        let component = if let Some(world) = world_name {
-            Component::from_raw_wit_package(&raw, world)?
-        } else {
-            Component::from_raw_component(&raw)?
-        };
+        let component = Component::from_raw_component(&raw)?;
         let config = Self {
             created: Utc::now(),
             author,
@@ -125,6 +118,7 @@ impl WasmConfig {
     }
 
     /// Adds annotations to this [`WasmConfig`].
+    #[must_use]
     pub fn with_annotations(
         &'_ self,
         annotations: HashMap<String, String>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -76,7 +76,6 @@ async fn test_push_and_pull() {
 
     let (conf, component) = WasmConfig::from_component(
         "./tests/data/component.wasm",
-        None,
         Some("Bugs Bunny".to_string()),
     )
     .await
@@ -207,7 +206,7 @@ async fn pulling_non_wasm_should_fail() {
 
 #[tokio::test]
 async fn test_binary_wit_parse() {
-    let (conf, _) = WasmConfig::from_component("./tests/data/binary_wit.wasm", Some("proxy"), None)
+    let (conf, _) = WasmConfig::from_component("./tests/data/binary_wit.wasm", None)
         .await
         .expect("Should be able to parse binary wit");
 
@@ -220,30 +219,21 @@ async fn test_binary_wit_parse() {
         .component
         .expect("Should have component information set in config");
 
-    let expected_exports = vec!["wasi:http/incoming-handler@0.2.0".to_string()];
-    let expected_imports = vec![
-        "wasi:cli/stderr@0.2.0".to_string(),
-        "wasi:cli/stdin@0.2.0".to_string(),
-        "wasi:cli/stdout@0.2.0".to_string(),
-        "wasi:clocks/monotonic-clock@0.2.0".to_string(),
-        "wasi:clocks/wall-clock@0.2.0".to_string(),
-        "wasi:http/outgoing-handler@0.2.0".to_string(),
+    let mut expected_exports = vec![
+        "wasi:http/incoming-handler@0.2.0".to_string(),
         "wasi:http/types@0.2.0".to_string(),
-        "wasi:io/error@0.2.0".to_string(),
-        "wasi:io/poll@0.2.0".to_string(),
-        "wasi:io/streams@0.2.0".to_string(),
+        "wasi:http/outgoing-handler@0.2.0".to_string(),
+        "wasi:http/proxy@0.2.0".to_string(),
+        "wasi:http/imports@0.2.0".to_string(),
     ];
+    expected_exports.sort();
 
-    let exports = component_info.exports;
-    let mut imports = component_info.imports;
-    imports.sort();
+    let mut exports = component_info.exports;
+    exports.sort();
 
     assert_eq!(
         exports, expected_exports,
         "Expected exports to match:\nGot: {exports:?}\nExpected:\n{expected_exports:?}"
     );
-    assert_eq!(
-        imports, expected_imports,
-        "Expected imports to match:\nGot: {imports:?}\nExpected:\n{expected_imports:?}"
-    );
+    assert!(component_info.imports.is_empty(), "Should have no imports");
 }


### PR DESCRIPTION
After talking with @lukewagner, I found out we shouldn't be requiring a world name for binary components and we should be just listing the exports of all the worlds